### PR TITLE
Fix bug in reporting template failure

### DIFF
--- a/lib/helpers/recurse_directory.rb
+++ b/lib/helpers/recurse_directory.rb
@@ -69,10 +69,10 @@ module Helpers
       wrapper.file = file.to_s
       wrapper.result
     rescue => ex
-      raise Puppet::ParseError, describe_template_failure(ex)
+      raise Puppet::ParseError, describe_template_failure(ex, file)
     end
 
-    def describe_template_failure(ex)
+    def describe_template_failure(ex, file)
       path, line_no = ex.backtrace.first.split(':', 2)
       format("Failed to parse template %s:\n  Filepath: %s\n  Line: %s\n  Detail: %s\n", file, path, line_no, ex)
     end


### PR DESCRIPTION
Error message was trying to display template file, which isn't available
to the method. Add as a parmeter to describe_template_failure.